### PR TITLE
Null check (See #29)

### DIFF
--- a/app/src/main/java/com/team3/fastcampus/record/Util/Permission/PermissionControllerActivity.java
+++ b/app/src/main/java/com/team3/fastcampus/record/Util/Permission/PermissionControllerActivity.java
@@ -18,8 +18,13 @@ public class PermissionControllerActivity extends AppCompatActivity {
     @Override
     protected void onStart() {
         super.onStart();
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+
+        PermissionController permissionController = PermissionController.getInstance();
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && permissionController != null) {
             requestPermissions(PermissionController.getInstance().getPermissionArray(), REQ_PERMISSION);
+        } else {
+            finish();
         }
     }
 


### PR DESCRIPTION
Null check를 함으로써 nullpoint exception이 발생하는 것을 해결함.

OS 버전이 `M`미만 또는 null인 경우 Activity 종료